### PR TITLE
Unity Package exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ ExportedObj/
 *.mdb
 *.opendb
 *.VC.db
+*.vscode
 
 # Unity3D generated meta files
 *.pidb.meta

--- a/Assets/ARWT.unitypackage.meta
+++ b/Assets/ARWT.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 462630f7b62883448b299d8aeb4ace21
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f58116185aab327458eb3cc783323562
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/UnityPackageExporter.cs
+++ b/Assets/Editor/UnityPackageExporter.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public static class UnityPackageExporter
+{
+    private static readonly string PACKAGE_FILE_NAME = Path.Combine(
+        path1: Application.dataPath,
+        path2: "ARWT.unitypackage"
+    );
+
+    private static readonly string[] ASSET_PATH_NAMES = new string[]
+    {
+        "Assets/WebGLTemplates",
+        "Assets/Resources/Prefabs",
+        "Assets/Plugins",
+        "Assets/Scripts"
+    };
+
+    [MenuItem("ARWT/Export Unity Package")]
+    public static void ExportPackage()
+    {
+        AssetDatabase.ExportPackage(
+            assetPathNames: ASSET_PATH_NAMES,
+            fileName: PACKAGE_FILE_NAME,
+            ExportPackageOptions.Recurse | ExportPackageOptions.Interactive
+        );
+        AssetDatabase.Refresh();
+    }
+}

--- a/Assets/Editor/UnityPackageExporter.cs
+++ b/Assets/Editor/UnityPackageExporter.cs
@@ -2,29 +2,32 @@
 using UnityEditor;
 using UnityEngine;
 
-public static class UnityPackageExporter
+namespace ARWT.Core
 {
-    private static readonly string PACKAGE_FILE_NAME = Path.Combine(
-        path1: Application.dataPath,
-        path2: "ARWT.unitypackage"
-    );
-
-    private static readonly string[] ASSET_PATH_NAMES = new string[]
+    public static class UnityPackageExporter
     {
+        private static readonly string PACKAGE_FILE_NAME = Path.Combine(
+            path1: Application.dataPath,
+            path2: "ARWT.unitypackage"
+        );
+
+        private static readonly string[] ASSET_PATH_NAMES = new string[]
+        {
         "Assets/WebGLTemplates",
         "Assets/Resources/Prefabs",
         "Assets/Plugins",
         "Assets/Scripts"
-    };
+        };
 
-    [MenuItem("ARWT/Export Unity Package")]
-    public static void ExportPackage()
-    {
-        AssetDatabase.ExportPackage(
-            assetPathNames: ASSET_PATH_NAMES,
-            fileName: PACKAGE_FILE_NAME,
-            ExportPackageOptions.Recurse | ExportPackageOptions.Interactive
-        );
-        AssetDatabase.Refresh();
+        [MenuItem("ARWT/Export Unity Package")]
+        public static void ExportPackage()
+        {
+            AssetDatabase.ExportPackage(
+                assetPathNames: ASSET_PATH_NAMES,
+                fileName: PACKAGE_FILE_NAME,
+                ExportPackageOptions.Recurse | ExportPackageOptions.Interactive
+            );
+            AssetDatabase.Refresh();
+        }
     }
 }

--- a/Assets/Editor/UnityPackageExporter.cs.meta
+++ b/Assets/Editor/UnityPackageExporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c92da0fe54dce8643b4186655f89c534
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ide.rider": "1.1.4",
-    "com.unity.ide.vscode": "1.2.1",
+    "com.unity.ide.vscode": "1.2.3",
     "com.unity.test-framework": "1.1.14",
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.timeline": "1.2.14",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -24,7 +24,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.vscode": {
-      "version": "1.2.1",
+      "version": "1.2.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
This editor script allows to export the minimal boilerplate code to be able to add webAR functionalities to a empty project.

The ideal plan is to use GitHub's Release page of the project to distribute ready-to-import packages, maintaining versions etc. 